### PR TITLE
fix: rotate armorstand to prevent texture overlaping

### DIFF
--- a/src/death/corpses.ts
+++ b/src/death/corpses.ts
@@ -120,7 +120,7 @@ export async function spawnCorpse(event: PlayerDeathEvent) {
 
   // Edit position
   armorstand.headPose = new EulerAngle(4.88, 0, 0);
-  armorstand.rightArmPose = new EulerAngle(0, 0, 0);
+  armorstand.rightArmPose = new EulerAngle(0.01, 0.01, 0.01);
 
   const body = getBody(event.entity.lastDamageCause?.cause).create();
   armorstand.setItem(EquipmentSlot.HAND, body);


### PR DESCRIPTION
old
![image](https://user-images.githubusercontent.com/46357265/106320010-f02dd600-627a-11eb-9676-78ec5a26d476.png)

new
![image](https://user-images.githubusercontent.com/46357265/106320045-fc199800-627a-11eb-8da2-3cb89453061c.png)
