### PR TITLE
fix: prevent anvils from breaking and fix barrel rotation

### DIFF
--- a/src/blacksmith/anvil.ts
+++ b/src/blacksmith/anvil.ts
@@ -1,23 +1,60 @@
 import { AnvilDamagedEvent } from 'com.destroystokyo.paper.event.block';
 import { Material } from 'org.bukkit';
-import { Player } from 'org.bukkit.entity';
+import { FallingBlock, Player } from 'org.bukkit.entity';
 import { EntityChangeBlockEvent } from 'org.bukkit.event.entity';
 import { InventoryClickEvent, InventoryType } from 'org.bukkit.event.inventory';
+import { BlockPlaceEvent } from 'org.bukkit.event.block';
+import { Directional } from 'org.bukkit.block.data';
+import { BlockFace } from 'org.bukkit.block';
 
+/**
+ * Prevent an anvil breaking in use
+ */
 registerEvent(AnvilDamagedEvent, (event) => {
   event.setCancelled(true);
 });
 
+/**
+ * Prevent any falling anvil from breaking
+ */
+const ANVILS = new Set([
+  Material.ANVIL,
+  Material.CHIPPED_ANVIL,
+  Material.DAMAGED_ANVIL,
+]);
 registerEvent(EntityChangeBlockEvent, async (event) => {
-  if (
-    event.to === Material.CHIPPED_ANVIL ||
-    event.to === Material.DAMAGED_ANVIL
-  ) {
-    await wait(1, 'millis'); // Wait 1 millis for the anvil to become a block
-    event.block.type = Material.ANVIL;
+  if (!(event.entity as FallingBlock)) return;
+  if (ANVILS.has((event.entity as FallingBlock).blockData.material)) {
+    // This is a hack. Other methods did not prevent every anvil type from breaking,
+    // but this seems to fix every issue
+    (event.entity as FallingBlock).fallDistance = -10000;
   }
 });
 
+/**
+ * Rotate fermentation barrel (anvil) 90 degrees,
+ * so the model is facing the right direction
+ *
+ * TODO: Move this to the alcohol folder
+ */
+const FERMENTATION_BARREL = Material.DAMAGED_ANVIL;
+const ROTATION = new Map([
+  [BlockFace.EAST, BlockFace.NORTH],
+  [BlockFace.NORTH, BlockFace.WEST],
+  [BlockFace.WEST, BlockFace.SOUTH],
+  [BlockFace.SOUTH, BlockFace.EAST],
+]);
+registerEvent(BlockPlaceEvent, (event) => {
+  if (event.block.type === FERMENTATION_BARREL) {
+    const anvilData = event.block.blockData as Directional;
+    anvilData.facing = ROTATION.get(anvilData.facing) ?? anvilData.facing;
+    event.block.blockData = anvilData;
+  }
+});
+
+/**
+ * Make anvill usage free (no exp required)
+ */
 registerEvent(InventoryClickEvent, async (event) => {
   const inventory = event.inventory;
   if (inventory.type !== InventoryType.ANVIL) return;


### PR DESCRIPTION
This prevents all anvil types from breaking

Barrels will now be facing the player when placed
![image](https://user-images.githubusercontent.com/46357265/108182469-b5002380-7111-11eb-855f-c0ddee6d2350.png)
