### PR TITLE
fix: disallow trying to shuffle deck with non-deck item in offhand

### DIFF
--- a/src/games/cards.ts
+++ b/src/games/cards.ts
@@ -272,6 +272,7 @@ async function shuffleDeck(
   secondDeck: ItemStack,
   player: Player,
 ) {
+  if(!deck) return;
   shuffleCooldowns.add(player);
   const d = getDeck(deck);
   if (!d) return;

--- a/src/games/cards.ts
+++ b/src/games/cards.ts
@@ -272,7 +272,7 @@ async function shuffleDeck(
   secondDeck: ItemStack,
   player: Player,
 ) {
-  if(!deck) return;
+  if(!isDeck(deck)) return;
   shuffleCooldowns.add(player);
   const d = getDeck(deck);
   if (!d) return;

--- a/src/games/cards.ts
+++ b/src/games/cards.ts
@@ -272,7 +272,6 @@ async function shuffleDeck(
   secondDeck: ItemStack,
   player: Player,
 ) {
-  if(!isDeck(deck)) return;
   shuffleCooldowns.add(player);
   const d = getDeck(deck);
   if (!d) return;
@@ -479,7 +478,7 @@ function clickedOnce(
   }
 
   // LEFT CLICK EVENTS - SHUFFLE / COMBINE / SPLIT DECK / INSERT CARD
-  if (isDeck(mainHandItem)) {
+  if (isDeck(mainHandItem) && isDeck(offHandItem)) {
     if (player.isSneaking()) {
       shuffleDeck(offHandItem, mainHandItem, player);
     } else {


### PR DESCRIPTION
Fix bug that requires players to relog if trying to shuffle deck with a non-deck item in the offhand or none.